### PR TITLE
fix: move css settings inside the object

### DIFF
--- a/src/style.less
+++ b/src/style.less
@@ -16,6 +16,12 @@
     div.material {
         height: 40px;
     }
+    .lui-button__text {
+        width: 100%;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+    }
     button {
         cursor: pointer;
         margin-right: 3px;
@@ -409,10 +415,4 @@
 			left: -9px;
 		}
 	} 
-}
-.lui-button__text {
-    width: 100%;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
 }


### PR DESCRIPTION
Had css settings outside to test the object as an extension, and missed to move them back inside the object later when checked in, works as expected now.
Attached is a screenshot for the language where it failed -

![Screenshot 2024-08-26 at 22 44 50](https://github.com/user-attachments/assets/1ea5fa41-6538-4321-83cf-f8e802c01dcf)
